### PR TITLE
Add support for multiple targets per server

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Octo-proxy or `octo` is simple TCP & TLS Proxy with mutual authentication and tr
 - Accept TCP connection and forward/mirror it to TLS (w/ mTLS)
 - Accept TLS (w/ mTLS) connection and forward/mirror it to TCP
 - Accept TLS (w/ mTLS) connection and forward/mirror it to TLS (w/ mTLS)
+- Support for multiple targets, accessed in random order (load balancer)
 - Reload configuration or certificate without dropping connection
 - Expose metrics that can be consumed by prometheus
 
@@ -25,9 +26,11 @@ servers:
   listener:
     host: 127.0.0.1
     port: 8080
-  target:
-    host: 127.0.0.1
-    port: 80
+  targets:
+    - host: 127.0.0.1
+      port: 80
+    - host: 127.0.0.1
+      port: 81
 ```
 
 ```
@@ -47,9 +50,9 @@ servers:
       caCert: /tmp/ca-cert.pem
       cert: /tmp/cert.pem
       key: /tmp/cert-key.pem
-  target:
-    host: 127.0.0.1
-    port: 80
+  targets:
+    - host: 127.0.0.1
+      port: 80
 ```
 
 ```
@@ -68,9 +71,9 @@ servers:
       mode: simple
       cert: /tmp/cert.pem
       key: /tmp/cert-key.pem
-  target:
-    host: 127.0.0.1
-    port: 80
+  targets:
+    - host: 127.0.0.1
+      port: 80
   mirror:
     host: 172.16.0.1
     port: 80

--- a/cmd/octo/main.go
+++ b/cmd/octo/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/nothinux/octo-proxy/pkg/config"
 	"github.com/nothinux/octo-proxy/pkg/runner"
@@ -48,7 +49,7 @@ func runMain() error {
 		configPath = flag.String("config", "config.yaml", "Specify config location path")
 		ver        = flag.Bool("version", false, "Print octo-proxy version")
 		listener   = flag.String("listener", "127.0.0.1:5000", "Specify listener for running octo-proxy")
-		target     = flag.String("target", "", "Specify target for running octo-proxy")
+		target     = flag.String("target", "", "Specify comma-separated list of targets for running octo-proxy")
 	)
 
 	flag.Usage = func() {
@@ -60,7 +61,9 @@ func runMain() error {
 
 	// run with flag
 	if *target != "" {
-		c, err := config.GenerateConfig(*listener, *target)
+		targets := strings.Split(*target, ",")
+
+		c, err := config.GenerateConfig(*listener, targets)
 		if err != nil {
 			return err
 		}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -8,11 +8,11 @@
 
 ## Server
 
-| Field    | Type          | Description   | Required |
-| -------- | ------------- | ------------- | -------- |
-| name     | `<string>`    | Name of proxy | no       |
-| listener | [`Hostconfig`](#hostconfig)  | Set of listener related configuration, all of incoming request to octo-proxy will be handled by this listener.            | yes      |
-| target   | [`Hostconfig`](#hostconfig)  | Set of target related configuration, this target is backend which octo-proxy will forward all incoming request accepted by listener.            | yes      |
+| Field    | Type             | Description   | Required |
+| -------- | ---------------- | ------------- | -------- |
+| name     | `<string>`       | Name of proxy | no       |
+| listener | [`Hostconfig`]   | (#hostconfig) | Set of listener related configuration, all of incoming request to octo-proxy will be handled by this listener.            | yes      |
+| targets  | [`Hostconfig[]`] | (#hostconfig) | Set of target related configurations. These targets are backends which octo-proxy will forward all incoming traffic accepted by the listener.            | yes      |
 | mirror   | [`Hostconfig`](#hostconfig)  | Set of mirror related configuration, if this configuration is set, all incoming request will also forwarded to this mirror, unlike target, in mirror we implement fire & forget, every request will only forwarded, and the response will be ignored.            | no       |
 
 ## Hostconfig

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -10,13 +10,13 @@ servers:
       caCert: certs/ca-cert.pem
     # set timeout default is 300
     timeout: 60
-  target:
-    host: 172.17.0.2
-    port: 80
-    timeout: 60
-    tlsConfig:
-      mode: simple
-      caCert: certs/ca-cert.pem
+  targets:
+    - host: 172.17.0.2
+      port: 80
+      timeout: 60
+      tlsConfig:
+        mode: simple
+        caCert: certs/ca-cert.pem
   mirror:
     host: 172.17.0.3
     port: 80

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"crypto/tls"
+	"fmt"
 	"io"
 	"log"
 	"net"
@@ -44,11 +45,17 @@ func (p *Proxy) Run(c config.ServerConfig) {
 		log.Fatal(err)
 	}
 
+	ts := []string{}
+
+	for _, target := range c.Targets {
+		ts = append(ts, fmt.Sprintf("%s:%s", target.Host, target.Port))
+	}
+
 	log.Printf(
-		"listening %s on %s:%s -> %s:%s",
+		"listening %s on %s:%s -> %v",
 		c.Name,
 		c.Listener.Host, c.Listener.Port,
-		c.Target.Host, c.Target.Port,
+		ts,
 	)
 
 	tc := c.Listener.TLSConfig

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -25,7 +25,7 @@ func TestRunningRunner(t *testing.T) {
 		t.Fatal(err)
 	}
 	// replace port in target with backend create previously
-	c.ServerConfigs[0].Target.Port = strings.Split(backend, ":")[1]
+	c.ServerConfigs[0].Targets[0].Port = strings.Split(backend, ":")[1]
 
 	// starting octo proxy
 	ss := &Server{c.ServerConfigs}

--- a/pkg/testdata/err-config.yaml
+++ b/pkg/testdata/err-config.yaml
@@ -3,6 +3,6 @@ servers:
   listener:
     host: 127.0.0.1
     port: 9999
-  target:
-    host: 
-    port: 80
+  targets:
+    - host: 
+      port: 80

--- a/pkg/testdata/rel-config.yaml
+++ b/pkg/testdata/rel-config.yaml
@@ -4,6 +4,6 @@ servers:
     host: 127.0.0.1
     port: 9999
     timeout: 60
-  target:
-    host: 127.0.0.1
-    port: 80
+  targets:
+    - host: 127.0.0.1
+      port: 80

--- a/pkg/testdata/run-config.yaml
+++ b/pkg/testdata/run-config.yaml
@@ -3,6 +3,6 @@ servers:
   listener:
     host: 127.0.0.1
     port: 9999
-  target:
-    host: 127.0.0.1
-    port: 80
+  targets:
+    - host: 127.0.0.1
+      port: 80

--- a/pkg/testdata/test-config.yaml
+++ b/pkg/testdata/test-config.yaml
@@ -9,13 +9,13 @@ servers:
       key: localhost-key.pem
       caCert: ca-cert.pem
     timeout: 60
-  target:
-    host: 172.17.0.2
-    port: 80
-    timeout: 60
-    tlsConfig:
-      mode: simple
-      caCert: ca-cert.pem
+  targets:
+    - host: 172.17.0.2
+      port: 80
+      timeout: 60
+      tlsConfig:
+        mode: simple
+        caCert: ca-cert.pem
   mirror:
     host: 172.17.0.3
     port: 80


### PR DESCRIPTION
This adds a load-balancer/fail-over feature that allows to specify multiple backend targets per server. Targets will be attempted in random order.

This is a breaking change that requires a configuration update for existing deployments.

All existing tests are still passing, and a new test was added to test the new feature.