### PR TITLE
Don't set default timeouts on listeners and targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ servers:
   listener:
     host: 0.0.0.0
     port: 8080
+    timeout: 300
     tlsConfig:
       mode: mutual
       caCert: /tmp/ca-cert.pem
@@ -59,6 +60,7 @@ servers:
   targets:
     - host: 127.0.0.1
       port: 80
+      timeout: 300
 
 metrics:
   host: 0.0.0.0
@@ -81,6 +83,7 @@ servers:
   listener:
     host: 0.0.0.0
     port: 8080
+    timeout: 300
     tlsConfig:
       mode: simple
       cert: /tmp/cert.pem
@@ -88,9 +91,11 @@ servers:
   targets:
     - host: 127.0.0.1
       port: 80
+      timeout: 300
   mirror:
     host: 172.16.0.1
     port: 80
+    timeout: 300
 ```
 
 ```

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -24,9 +24,11 @@ servers:
   listener:
     host: 127.0.0.1
     port: 8081
+    timeout: 300
   targets:
     - host: 127.0.0.1
       port: 80
+      timeout: 300
 
 metrics:
   host: 0.0.0.0

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,8 @@ const (
 	smirror
 )
 
+const defaultTimeout = 300
+
 type Config struct {
 	ServerConfigs []ServerConfig `yaml:"servers"`
 	MetricsConfig HostConfig     `yaml:"metrics"`
@@ -113,8 +115,9 @@ func GenerateConfig(listener string, targets []string, metrics string) (*Config,
 			{
 				Name: "default",
 				Listener: HostConfig{
-					Host: l[0],
-					Port: l[1],
+					Host:    l[0],
+					Port:    l[1],
+					Timeout: defaultTimeout,
 				},
 				Targets: []HostConfig{},
 			},
@@ -128,8 +131,9 @@ func GenerateConfig(listener string, targets []string, metrics string) (*Config,
 		}
 
 		hc := HostConfig{
-			Host: t[0],
-			Port: t[1],
+			Host:    t[0],
+			Port:    t[1],
+			Timeout: defaultTimeout,
 		}
 
 		c.ServerConfigs[0].Targets = append(c.ServerConfigs[0].Targets, hc)
@@ -176,7 +180,6 @@ func validateConfig(c *Config) (*Config, error) {
 				return nil, err
 			}
 
-			setTimeout(&c.ServerConfigs[i].Targets[j])
 			setSAN(&c.ServerConfigs[i].Targets[j])
 		}
 
@@ -186,7 +189,6 @@ func validateConfig(c *Config) (*Config, error) {
 				return nil, err
 			}
 
-			setTimeout(mirror)
 			setSAN(mirror)
 		}
 		// set all listener role to server
@@ -194,17 +196,10 @@ func validateConfig(c *Config) (*Config, error) {
 			listener.TLSConfig.Role.Server = true
 		}
 
-		setTimeout(listener)
 		setSAN(listener)
 	}
 
 	return c, nil
-}
-
-func setTimeout(c *HostConfig) {
-	if c.Timeout == 0 {
-		c.Timeout = 300
-	}
 }
 
 func setSAN(c *HostConfig) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -287,13 +287,15 @@ func TestValidateConfig(t *testing.T) {
 					{
 						Name: "proxy-1",
 						Listener: HostConfig{
-							Host: "127.0.0.1",
-							Port: "8080",
+							Host:    "127.0.0.1",
+							Port:    "8080",
+							Timeout: 30,
 						},
 						Targets: []HostConfig{
 							{
-								Host: "127.0.0.1",
-								Port: "80",
+								Host:    "127.0.0.1",
+								Port:    "80",
+								Timeout: 30,
 							},
 						},
 					},
@@ -306,13 +308,13 @@ func TestValidateConfig(t *testing.T) {
 						Listener: HostConfig{
 							Host:    "127.0.0.1",
 							Port:    "8080",
-							Timeout: 300,
+							Timeout: 30,
 						},
 						Targets: []HostConfig{
 							{
 								Host:    "127.0.0.1",
 								Port:    "80",
-								Timeout: 300,
+								Timeout: 30,
 							},
 						},
 					},
@@ -595,104 +597,15 @@ func TestValidateConfig(t *testing.T) {
 			expectedError:  "port in servers.[0].mirror.port is not valid",
 		},
 		{
-			Name: "set timeout on listener",
-			Config: &Config{
-				ServerConfigs: []ServerConfig{
-					{
-						Name: "proxy-1",
-						Listener: HostConfig{
-							Host:    "127.0.0.1",
-							Port:    "8080",
-							Timeout: 10,
-						},
-						Targets: []HostConfig{
-							{
-								Host: "127.0.0.1",
-								Port: "80",
-							},
-						},
-					},
-				},
-			},
-			expectedConfig: &Config{
-				ServerConfigs: []ServerConfig{
-					{
-						Name: "proxy-1",
-						Listener: HostConfig{
-							Host:    "127.0.0.1",
-							Port:    "8080",
-							Timeout: 10,
-						},
-						Targets: []HostConfig{
-							{
-								Host:    "127.0.0.1",
-								Port:    "80",
-								Timeout: 300,
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			Name: "set timeout on listener, target and set mirror to default",
-			Config: &Config{
-				ServerConfigs: []ServerConfig{
-					{
-						Name: "proxy-1",
-						Listener: HostConfig{
-							Host:    "127.0.0.1",
-							Port:    "8080",
-							Timeout: 10,
-						},
-						Targets: []HostConfig{
-							{
-								Host:    "127.0.0.1",
-								Port:    "80",
-								Timeout: 200,
-							},
-						},
-						Mirror: HostConfig{
-							Host: "127.0.0.1",
-							Port: "9999",
-						},
-					},
-				},
-			},
-			expectedConfig: &Config{
-				ServerConfigs: []ServerConfig{
-					{
-						Name: "proxy-1",
-						Listener: HostConfig{
-							Host:    "127.0.0.1",
-							Port:    "8080",
-							Timeout: 10,
-						},
-						Targets: []HostConfig{
-							{
-								Host:    "127.0.0.1",
-								Port:    "80",
-								Timeout: 200,
-							},
-						},
-						Mirror: HostConfig{
-							Host:    "127.0.0.1",
-							Port:    "9999",
-							Timeout: 300,
-						},
-					},
-				},
-			},
-		},
-		{
 			Name: "valid tlsConfig on listener",
 			Config: &Config{
 				ServerConfigs: []ServerConfig{
 					{
 						Name: "proxy-1",
 						Listener: HostConfig{
-							Host: "127.0.0.1",
-							Port: "8080",
+							Host:    "127.0.0.1",
+							Port:    "8080",
+							Timeout: 300,
 							TLSConfig: TLSConfig{
 								Mode:   "mutual",
 								Key:    "/tmp/key.pem",
@@ -702,8 +615,9 @@ func TestValidateConfig(t *testing.T) {
 						},
 						Targets: []HostConfig{
 							{
-								Host: "127.0.0.1",
-								Port: "80",
+								Host:    "127.0.0.1",
+								Port:    "80",
+								Timeout: 300,
 							},
 						},
 					},

--- a/pkg/proxy/dialer.go
+++ b/pkg/proxy/dialer.go
@@ -50,7 +50,12 @@ func dialTargets(hcs []config.HostConfig) (net.Conn, error) {
 	for _, hc := range hcs {
 		c, err := dialTarget(hc)
 		if err == nil {
-			c.SetDeadline(time.Now().Add(time.Second * time.Duration(hc.Timeout)))
+			if hc.Timeout > 0 {
+				deadline := time.Now().Add(time.Second * time.Duration(hc.Timeout))
+				if err := c.SetDeadline(deadline); err != nil {
+					log.Error().Err(err).Msg("failed to set target conn deadline")
+				}
+			}
 			return c, nil
 		}
 
@@ -85,7 +90,12 @@ func getTargets(c config.ServerConfig) ([]net.Conn, io.Writer, error) {
 				Msg("can't dial mirror backend")
 		}
 		if m != nil {
-			m.SetDeadline(time.Now().Add(time.Second * time.Duration(c.Mirror.Timeout)))
+			if c.Mirror.Timeout > 0 {
+				deadline := time.Now().Add(time.Second * time.Duration(c.Mirror.Timeout))
+				if err := m.SetDeadline(deadline); err != nil {
+					log.Error().Err(err).Msg("failed to set mirror conn deadline")
+				}
+			}
 		}
 	}
 

--- a/pkg/testdata/run-config.yaml
+++ b/pkg/testdata/run-config.yaml
@@ -3,6 +3,8 @@ servers:
   listener:
     host: 127.0.0.1
     port: 9999
+    timeout: 30
   targets:
     - host: 127.0.0.1
       port: 80
+      timeout: 30


### PR DESCRIPTION
Currently, the config vaidator will set a timeout of 300 if the value isn't specificed. So in other words, there is no way to set the timeout to 0, which is a problem for long-standing connections.

This patch changes that, and leaves the default on 0 and makes sure the deadlines are only set on connections that have a timeout configured.

`GenerateConfig` however will set this default, so the behaviour in config-less scenario is retained.