### PR TITLE
Make test coverage better

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ metrics:
 octo -config config.yaml
 ```
 
-#### Run Octo as TLS Proxy w/ mTLS and TLS enabled metrics server
+#### Run Octo as TLS Proxy w/ mTLS
 ``` yaml
 // config.yaml
 servers:
@@ -63,10 +63,6 @@ servers:
 metrics:
   host: 0.0.0.0
   port: 9123
-  tlsConfig:
-    mode: simple
-    cert: /tmp/cert.pem
-    key: /tmp/cert-key.pem
 ```
 
 ```

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -42,4 +42,4 @@
 ## Metrics
 | Field    | Type          | Description                     |                                                 | Required |
 | -------- | ------------- | ------------------------------- | ----------------------------------------------- | -------- |
-| metrics  | [HostConfig]  | Configures the host and port for the metrics server, optionally with TLS settings | no       |
+| metrics  | [HostConfig]  | Configures the host and port for the metrics server, currently doesn't support tls settings | no       |

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/nothinux/octo-proxy/pkg/config"
-	"github.com/nothinux/octo-proxy/pkg/tlsconn"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -18,17 +17,11 @@ func New(c config.HostConfig) (*Metrics, error) {
 	r := http.NewServeMux()
 	r.Handle("/metrics", promhttp.Handler())
 
-	tlsConf, err := tlsconn.GetTLSConfig(c.TLSConfig)
-	if err != nil {
-		return nil, err
-	}
-
 	srv := &http.Server{
 		Handler:      r,
 		Addr:         fmt.Sprintf("%s:%s", c.Host, c.Port),
 		ReadTimeout:  5 * time.Second,
 		WriteTimeout: 5 * time.Second,
-		TLSConfig:    tlsConf.Config,
 	}
 
 	return &Metrics{srv}, nil

--- a/pkg/proxy/dialer.go
+++ b/pkg/proxy/dialer.go
@@ -11,7 +11,7 @@ import (
 	"github.com/nothinux/octo-proxy/pkg/config"
 	"github.com/nothinux/octo-proxy/pkg/errors"
 	"github.com/nothinux/octo-proxy/pkg/metrics"
-	"github.com/nothinux/octo-proxy/pkg/tlsconn"
+
 	"github.com/rs/zerolog/log"
 )
 
@@ -30,7 +30,7 @@ func dialTarget(hc config.HostConfig) (net.Conn, error) {
 	d := newDial()
 
 	if hc.IsSimple() || hc.IsMutual() {
-		tlsConf, err := tlsconn.GetTLSConfig(hc.TLSConfig)
+		tlsConf, err := getTLSConfig(hc.TLSConfig)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -12,7 +12,6 @@ import (
 	reuseport "github.com/kavu/go_reuseport"
 	"github.com/nothinux/octo-proxy/pkg/config"
 	"github.com/nothinux/octo-proxy/pkg/metrics"
-	"github.com/nothinux/octo-proxy/pkg/tlsconn"
 	"github.com/rs/zerolog/log"
 )
 
@@ -62,7 +61,7 @@ func (p *Proxy) Run(c config.ServerConfig) {
 
 	tc := c.Listener.TLSConfig
 	if tc.IsSimple() || tc.IsMutual() {
-		tlsConf, err := tlsconn.GetTLSConfig(tc)
+		tlsConf, err := getTLSConfig(tc)
 		if err != nil {
 			log.Fatal().Err(err).Msg("failed to get TLS config")
 		}

--- a/pkg/proxy/tlsconn.go
+++ b/pkg/proxy/tlsconn.go
@@ -1,4 +1,5 @@
-package tlsconn
+// TODO: separate this usecase to new package
+package proxy
 
 import (
 	"crypto/tls"
@@ -23,8 +24,8 @@ func newTLS() *ProxyTLS {
 	}
 }
 
-// GetTLSConfig returns a TLS Config for the simple and mutual tls
-func GetTLSConfig(c config.TLSConfig) (*ProxyTLS, error) {
+// getTLSConfig returns a TLS Config for the simple and mutual tls
+func getTLSConfig(c config.TLSConfig) (*ProxyTLS, error) {
 	var caPool *x509.CertPool
 	var pair tls.Certificate
 	var err error

--- a/pkg/proxy/tlsconn_test.go
+++ b/pkg/proxy/tlsconn_test.go
@@ -1,4 +1,4 @@
-package tlsconn
+package proxy
 
 import (
 	"crypto/tls"
@@ -43,7 +43,6 @@ func TestGetCACertPool(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
 			_, err := getCACertPool(tt.Config)
-			t.Log(err)
 			if err != tt.wantError {
 				if !strings.Contains(err.Error(), tt.wantError.Error()) {
 					t.Fatalf("got %v, want %v", err, tt.wantError)

--- a/pkg/proxy/utils_test.go
+++ b/pkg/proxy/utils_test.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 
 	"github.com/nothinux/octo-proxy/pkg/config"
-	"github.com/nothinux/octo-proxy/pkg/tlsconn"
 )
 
 func SendData(hc config.HostConfig, message []byte, readResponse bool) error {
@@ -37,7 +36,7 @@ func SendData(hc config.HostConfig, message []byte, readResponse bool) error {
 }
 
 func RunTestTLSServer(wg *sync.WaitGroup, c config.TLSConfig, result chan []byte) string {
-	tlsConfig, err := tlsconn.GetTLSConfig(c)
+	tlsConfig, err := getTLSConfig(c)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/tlsconn/tlsconn.go
+++ b/pkg/tlsconn/tlsconn.go
@@ -102,7 +102,7 @@ func getCACertPool(c config.TLSConfig) (*x509.CertPool, error) {
 
 	pool := x509.NewCertPool()
 	if ok := pool.AppendCertsFromPEM(cacert); !ok {
-		return nil, errors.New("tlsConfig", "can't add CA to pool "+err.Error())
+		return nil, errors.New("tlsConfig", "can't add CA to pool")
 	}
 
 	return pool, nil

--- a/pkg/tlsconn/tlsconn_test.go
+++ b/pkg/tlsconn/tlsconn_test.go
@@ -2,7 +2,11 @@ package tlsconn
 
 import (
 	"crypto/tls"
+	"errors"
+	"strings"
 	"testing"
+
+	"github.com/nothinux/octo-proxy/pkg/config"
 )
 
 func TestNewTLS(t *testing.T) {
@@ -10,5 +14,41 @@ func TestNewTLS(t *testing.T) {
 
 	if pTLS.MinVersion != tls.VersionTLS12 {
 		t.Fatalf("got %v, want %v", pTLS.MinVersion, tls.VersionTLS12)
+	}
+}
+
+func TestGetCACertPool(t *testing.T) {
+	tests := []struct {
+		Name      string
+		Config    config.TLSConfig
+		wantError error
+	}{
+		{
+			Name:      "Check ca-cert file",
+			Config:    config.TLSConfig{CaCert: "../testdata/ca-cert.pem"},
+			wantError: nil,
+		},
+		{
+			Name:      "Check if ca-cert file not found",
+			Config:    config.TLSConfig{CaCert: "/tmp/zzz"},
+			wantError: errors.New("no such file or directory"),
+		},
+		{
+			Name:      "Check not ca-cert file",
+			Config:    config.TLSConfig{CaCert: "../testdata/file"},
+			wantError: errors.New("can't add CA to pool"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			_, err := getCACertPool(tt.Config)
+			t.Log(err)
+			if err != tt.wantError {
+				if !strings.Contains(err.Error(), tt.wantError.Error()) {
+					t.Fatalf("got %v, want %v", err, tt.wantError)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Move  `tlsconn`  use case to `proxy` package for better test visibility and coverage.

TODO: separate the `tlsconn` package and add tls support to metrics again.