### PR TITLE
Allow setting connection timeouts to zero

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -19,7 +19,7 @@
 | --------- | ------------- | ------------------------------- | -------- |
 | host      | `<string>`    | On `listener`, this is host where listener will be listen, and on `target` and `mirror` this is host of backend where request will be forwarded | yes      |
 | port      | `<string>`    | On `listener`, this is port where listener will be bind, and on `target` and `mirror` this is port of backend where request will be forwarded | yes      |
-| timeout   | `<string>`    | set timeout (in second) or deadline for every connection, default 300 seconds | no      |
+| timeout   | `<string>`    | set timeout (in second) or deadline for every connection, default 300 seconds. A value of 0 will disable deadlines on connections | no      |
 | tlsConfig | [`tlsConfig`](#tlsconfig)   | set tls configuration if host use tls | no      |
 
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 var (
@@ -126,15 +127,15 @@ func TestGenerateConfig(t *testing.T) {
 					{
 						Name: "default",
 						Listener: HostConfig{
-							Host:    "127.0.0.1",
-							Port:    "8080",
-							Timeout: 300,
+							Host:            "127.0.0.1",
+							Port:            "8080",
+							TimeoutDuration: 300 * time.Second,
 						},
 						Targets: []HostConfig{
 							{
-								Host:    "127.0.0.1",
-								Port:    "80",
-								Timeout: 300,
+								Host:            "127.0.0.1",
+								Port:            "80",
+								TimeoutDuration: 300 * time.Second,
 							},
 						},
 					},
@@ -304,15 +305,15 @@ func TestValidateConfig(t *testing.T) {
 					{
 						Name: "proxy-1",
 						Listener: HostConfig{
-							Host:    "127.0.0.1",
-							Port:    "8080",
-							Timeout: 300,
+							Host:            "127.0.0.1",
+							Port:            "8080",
+							TimeoutDuration: 300 * time.Second,
 						},
 						Targets: []HostConfig{
 							{
-								Host:    "127.0.0.1",
-								Port:    "80",
-								Timeout: 300,
+								Host:            "127.0.0.1",
+								Port:            "80",
+								TimeoutDuration: 300 * time.Second,
 							},
 						},
 					},
@@ -603,7 +604,7 @@ func TestValidateConfig(t *testing.T) {
 						Listener: HostConfig{
 							Host:    "127.0.0.1",
 							Port:    "8080",
-							Timeout: 10,
+							Timeout: "10",
 						},
 						Targets: []HostConfig{
 							{
@@ -619,20 +620,180 @@ func TestValidateConfig(t *testing.T) {
 					{
 						Name: "proxy-1",
 						Listener: HostConfig{
-							Host:    "127.0.0.1",
-							Port:    "8080",
-							Timeout: 10,
+							Host:            "127.0.0.1",
+							Port:            "8080",
+							Timeout:         "10",
+							TimeoutDuration: 10 * time.Second,
 						},
 						Targets: []HostConfig{
 							{
-								Host:    "127.0.0.1",
-								Port:    "80",
-								Timeout: 300,
+								Host:            "127.0.0.1",
+								Port:            "80",
+								TimeoutDuration: 300 * time.Second,
 							},
 						},
 					},
 				},
 			},
+		},
+		{
+			Name: "set zero timeout",
+			Config: &Config{
+				ServerConfigs: []ServerConfig{
+					{
+						Name: "proxy-1",
+						Listener: HostConfig{
+							Host:    "127.0.0.1",
+							Port:    "8080",
+							Timeout: "0",
+						},
+						Targets: []HostConfig{
+							{
+								Host:    "127.0.0.1",
+								Port:    "80",
+								Timeout: "0",
+							},
+						},
+					},
+				},
+			},
+			expectedConfig: &Config{
+				ServerConfigs: []ServerConfig{
+					{
+						Name: "proxy-1",
+						Listener: HostConfig{
+							Host:            "127.0.0.1",
+							Port:            "8080",
+							Timeout:         "0",
+							TimeoutDuration: 0,
+						},
+						Targets: []HostConfig{
+							{
+								Host:            "127.0.0.1",
+								Port:            "80",
+								Timeout:         "0",
+								TimeoutDuration: 0,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "set zero timeout",
+			Config: &Config{
+				ServerConfigs: []ServerConfig{
+					{
+						Name: "proxy-1",
+						Listener: HostConfig{
+							Host:    "127.0.0.1",
+							Port:    "8080",
+							Timeout: "0",
+						},
+						Targets: []HostConfig{
+							{
+								Host:    "127.0.0.1",
+								Port:    "80",
+								Timeout: "0",
+							},
+						},
+					},
+				},
+			},
+			expectedConfig: &Config{
+				ServerConfigs: []ServerConfig{
+					{
+						Name: "proxy-1",
+						Listener: HostConfig{
+							Host:            "127.0.0.1",
+							Port:            "8080",
+							Timeout:         "0",
+							TimeoutDuration: 0,
+						},
+						Targets: []HostConfig{
+							{
+								Host:            "127.0.0.1",
+								Port:            "80",
+								Timeout:         "0",
+								TimeoutDuration: 0,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "set invalid timeout on listener",
+			Config: &Config{
+				ServerConfigs: []ServerConfig{
+					{
+						Name: "proxy-1",
+						Listener: HostConfig{
+							Host:    "127.0.0.1",
+							Port:    "8080",
+							Timeout: "foo",
+						},
+						Targets: []HostConfig{
+							{
+								Host: "127.0.0.1",
+								Port: "80",
+							},
+						},
+					},
+				},
+			},
+			expectedConfig: nil,
+			expectedError:  "failed to parse timeout servers.[0]: strconv.Atoi: parsing \"foo\": invalid syntax",
+		},
+		{
+			Name: "set invalid timeout on listener",
+			Config: &Config{
+				ServerConfigs: []ServerConfig{
+					{
+						Name: "proxy-1",
+						Listener: HostConfig{
+							Host: "127.0.0.1",
+							Port: "8080",
+						},
+						Targets: []HostConfig{
+							{
+								Host:    "127.0.0.1",
+								Port:    "80",
+								Timeout: "foo",
+							},
+						},
+					},
+				},
+			},
+			expectedConfig: nil,
+			expectedError:  "failed to parse timeout servers.[0].targets[0]: strconv.Atoi: parsing \"foo\": invalid syntax",
+		},
+		{
+			Name: "set invalid timeout on mirror",
+			Config: &Config{
+				ServerConfigs: []ServerConfig{
+					{
+						Name: "proxy-1",
+						Listener: HostConfig{
+							Host: "127.0.0.1",
+							Port: "8080",
+						},
+						Targets: []HostConfig{
+							{
+								Host: "127.0.0.1",
+								Port: "80",
+							},
+						},
+						Mirror: HostConfig{
+							Host:    "127.0.0.1",
+							Port:    "81",
+							Timeout: "foo",
+						},
+					},
+				},
+			},
+			expectedConfig: nil,
+			expectedError:  "failed to parse timeout servers.[0].mirror: strconv.Atoi: parsing \"foo\": invalid syntax",
 		},
 		{
 			Name: "set timeout on listener, target and set mirror to default",
@@ -643,13 +804,13 @@ func TestValidateConfig(t *testing.T) {
 						Listener: HostConfig{
 							Host:    "127.0.0.1",
 							Port:    "8080",
-							Timeout: 10,
+							Timeout: "10",
 						},
 						Targets: []HostConfig{
 							{
 								Host:    "127.0.0.1",
 								Port:    "80",
-								Timeout: 200,
+								Timeout: "200",
 							},
 						},
 						Mirror: HostConfig{
@@ -664,21 +825,23 @@ func TestValidateConfig(t *testing.T) {
 					{
 						Name: "proxy-1",
 						Listener: HostConfig{
-							Host:    "127.0.0.1",
-							Port:    "8080",
-							Timeout: 10,
+							Host:            "127.0.0.1",
+							Port:            "8080",
+							Timeout:         "10",
+							TimeoutDuration: 10 * time.Second,
 						},
 						Targets: []HostConfig{
 							{
-								Host:    "127.0.0.1",
-								Port:    "80",
-								Timeout: 200,
+								Host:            "127.0.0.1",
+								Port:            "80",
+								Timeout:         "200",
+								TimeoutDuration: 200 * time.Second,
 							},
 						},
 						Mirror: HostConfig{
-							Host:    "127.0.0.1",
-							Port:    "9999",
-							Timeout: 300,
+							Host:            "127.0.0.1",
+							Port:            "9999",
+							TimeoutDuration: 300 * time.Second,
 						},
 					},
 				},
@@ -714,9 +877,9 @@ func TestValidateConfig(t *testing.T) {
 					{
 						Name: "proxy-1",
 						Listener: HostConfig{
-							Host:    "127.0.0.1",
-							Port:    "8080",
-							Timeout: 300,
+							Host:            "127.0.0.1",
+							Port:            "8080",
+							TimeoutDuration: 300 * time.Second,
 							TLSConfig: TLSConfig{
 								Role: Role{
 									Server: true,
@@ -729,9 +892,9 @@ func TestValidateConfig(t *testing.T) {
 						},
 						Targets: []HostConfig{
 							{
-								Host:    "127.0.0.1",
-								Port:    "80",
-								Timeout: 300,
+								Host:            "127.0.0.1",
+								Port:            "80",
+								TimeoutDuration: 300 * time.Second,
 							},
 						},
 					},

--- a/pkg/proxy/dialer.go
+++ b/pkg/proxy/dialer.go
@@ -50,7 +50,12 @@ func dialTargets(hcs []config.HostConfig) (net.Conn, error) {
 	for _, hc := range hcs {
 		c, err := dialTarget(hc)
 		if err == nil {
-			c.SetDeadline(time.Now().Add(time.Second * time.Duration(hc.Timeout)))
+			t := hc.TimeoutDuration
+			if t > 0 {
+				if err := c.SetDeadline(time.Now().Add(t)); err != nil {
+					log.Error().Err(err).Msg("Failed to set deadline")
+				}
+			}
 			return c, nil
 		}
 
@@ -85,7 +90,12 @@ func getTargets(c config.ServerConfig) ([]net.Conn, io.Writer, error) {
 				Msg("can't dial mirror backend")
 		}
 		if m != nil {
-			m.SetDeadline(time.Now().Add(time.Second * time.Duration(c.Mirror.Timeout)))
+			t := c.Mirror.TimeoutDuration
+			if t > 0 {
+				if err := m.SetDeadline(time.Now().Add(t)); err != nil {
+					log.Error().Err(err).Msg("Failed to set deadline for mirror")
+				}
+			}
 		}
 	}
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -119,7 +119,12 @@ func (p *Proxy) handleConn(c config.ServerConfig) {
 		defer activeConn.Dec()
 		activeConnTotal.Inc()
 
-		srcConn.SetDeadline(time.Now().Add(time.Second * time.Duration(c.Listener.Timeout)))
+		t := c.Listener.TimeoutDuration
+		if t > 0 {
+			if err := srcConn.SetDeadline(time.Now().Add(t)); err != nil {
+				log.Error().Err(err).Msg("Failed to set src conn deadline")
+			}
+		}
 
 		if err := isTLSConn(srcConn); err != nil {
 			log.Error().Err(err).Msg("connection error")

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -109,9 +109,9 @@ func TestProxyWithMirror(t *testing.T) {
 		t.Fatal(err)
 	}
 	cfg.ServerConfigs[0].Mirror = config.HostConfig{
-		Host:    strings.Split(mirror, ":")[0],
-		Port:    strings.Split(mirror, ":")[1],
-		Timeout: 10,
+		Host:            strings.Split(mirror, ":")[0],
+		Port:            strings.Split(mirror, ":")[1],
+		TimeoutDuration: 10 * time.Second,
 	}
 
 	p := New("test-proxy")
@@ -666,7 +666,7 @@ func TestProxyWithSlowTarget(t *testing.T) {
 		t.Fatal(err)
 	}
 	// set timeout for target
-	cfg.ServerConfigs[0].Targets[0].Timeout = 3
+	cfg.ServerConfigs[0].Targets[0].TimeoutDuration = 3 * time.Second
 
 	p := New("test-proxy")
 	go func() {


### PR DESCRIPTION
There is currently no way to disable the connection deadlines. The values default to 300 if the config yields 0, which is a problem for long-standing connections.

To fix this, treat the config value as string and only apply the default if the string is empty.