### PR TITLE
introduce new metrics upstream and downstream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/kavu/go_reuseport v1.5.0
 	github.com/okzk/sdnotify v0.0.0-20180710141335-d9becc38acbd
 	github.com/prometheus/client_golang v1.12.2
+	github.com/prometheus/client_model v0.3.0
 	github.com/rs/zerolog v1.28.0
 	gopkg.in/yaml.v2 v2.4.0
 )
@@ -18,7 +19,6 @@ require (
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,9 @@ github.com/prometheus/client_golang v1.12.2/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrb
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/prometheus/client_model v0.2.0 h1:uq5h0d+GuxiXLJLNABMgp2qUWDPiLvgCzz2dUR+/W/M=
 github.com/prometheus/client_model v0.2.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/prometheus/client_model v0.3.0 h1:UBgGFHqYdG/TPFD1B1ogZywDqEkwp3fBMvqdiQ7Xew4=
+github.com/prometheus/client_model v0.3.0/go.mod h1:LDGWKZIo7rky3hgvBe+caln+Dr3dPggB5dvjtD7w9+w=
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/common v0.26.0/go.mod h1:M7rCNAaPfAosfx8veZJCuw84e35h3Cfd9VFqTh1DIvc=

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -5,16 +5,30 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-func AddGauge(name, help string) prometheus.Gauge {
-	return promauto.NewGauge(prometheus.GaugeOpts{
+func AddGaugeVec(name, help string) *prometheus.GaugeVec {
+	return promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: name,
 		Help: help,
-	})
+	}, []string{"name"})
 }
 
-func AddCounter(name, help string) prometheus.Counter {
-	return promauto.NewCounter(prometheus.CounterOpts{
+func AddGaugeVecMultiLabels(name, help string) *prometheus.GaugeVec {
+	return promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: name,
 		Help: help,
-	})
+	}, []string{"host", "port"})
+}
+
+func AddCounterVec(name, help string) *prometheus.CounterVec {
+	return promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: name,
+		Help: help,
+	}, []string{"name"})
+}
+
+func AddCounterVecMultiLabels(name, help string) *prometheus.CounterVec {
+	return promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: name,
+		Help: help,
+	}, []string{"host", "port"})
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,204 @@
+package metrics
+
+import (
+	"reflect"
+	"testing"
+
+	pcm "github.com/prometheus/client_model/go"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestAddGaugeVec(t *testing.T) {
+	tests := []struct {
+		Name            string
+		MetricsName     string
+		MetricsHelp     string
+		Labels          prometheus.Labels
+		ExpectedMetrics *prometheus.Desc
+	}{
+		{
+			Name:        "Test metrics is correct",
+			MetricsName: "example_metrics",
+			MetricsHelp: "help",
+			Labels:      prometheus.Labels{"name": "www"},
+			ExpectedMetrics: prometheus.NewDesc(
+				"example_metrics",
+				"help",
+				[]string{"name"},
+				prometheus.Labels{},
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			m := AddGaugeVec(tt.MetricsName, tt.MetricsHelp)
+
+			if !reflect.DeepEqual(m.With(tt.Labels).Desc(), tt.ExpectedMetrics) {
+				t.Fatalf("got %v, want %v", m.With(tt.Labels).Desc(), tt.ExpectedMetrics)
+			}
+
+			metrics := &pcm.Metric{}
+
+			t.Run("Test increase value", func(t *testing.T) {
+				m.With(tt.Labels).Inc()
+				m.With(tt.Labels).Write(metrics)
+
+				if metrics.Gauge.GetValue() != 1 {
+					t.Fatalf("got %v, want %v", metrics.Gauge.GetValue(), 1)
+				}
+			})
+
+			t.Run("Test decrease value", func(t *testing.T) {
+				m.With(tt.Labels).Dec()
+				m.With(tt.Labels).Write(metrics)
+
+				if metrics.Gauge.GetValue() != 0 {
+					t.Fatalf("got %v, want %v", metrics.Gauge.GetValue(), 0)
+				}
+			})
+		})
+	}
+}
+
+func TestAddCounterVec(t *testing.T) {
+	tests := []struct {
+		Name            string
+		MetricsName     string
+		MetricsHelp     string
+		Labels          prometheus.Labels
+		ExpectedMetrics *prometheus.Desc
+	}{
+		{
+			Name:        "Test metrics is correct",
+			MetricsName: "example_metrics_counter",
+			MetricsHelp: "help",
+			Labels:      prometheus.Labels{"name": "www"},
+			ExpectedMetrics: prometheus.NewDesc(
+				"example_metrics_counter",
+				"help",
+				[]string{"name"},
+				prometheus.Labels{},
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			m := AddCounterVec(tt.MetricsName, tt.MetricsHelp)
+
+			if !reflect.DeepEqual(m.With(tt.Labels).Desc(), tt.ExpectedMetrics) {
+				t.Fatalf("got %v, want %v", m.With(tt.Labels).Desc(), tt.ExpectedMetrics)
+			}
+
+			metrics := &pcm.Metric{}
+
+			t.Run("Test increase value", func(t *testing.T) {
+				m.With(tt.Labels).Inc()
+				m.With(tt.Labels).Write(metrics)
+
+				if metrics.Counter.GetValue() != 1 {
+					t.Fatalf("got %v, want %v", metrics.Counter.GetValue(), 1)
+				}
+			})
+		})
+	}
+}
+
+func TestAddGaugeVecMultiLabels(t *testing.T) {
+	tests := []struct {
+		Name            string
+		MetricsName     string
+		MetricsHelp     string
+		Labels          prometheus.Labels
+		ExpectedMetrics *prometheus.Desc
+	}{
+		{
+			Name:        "Test metrics is correct",
+			MetricsName: "example_metrics_m",
+			MetricsHelp: "help",
+			Labels:      prometheus.Labels{"host": "127.0.0.1", "port": "8080"},
+			ExpectedMetrics: prometheus.NewDesc(
+				"example_metrics_m",
+				"help",
+				[]string{"host", "port"},
+				prometheus.Labels{},
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			m := AddGaugeVecMultiLabels(tt.MetricsName, tt.MetricsHelp)
+
+			if !reflect.DeepEqual(m.With(tt.Labels).Desc(), tt.ExpectedMetrics) {
+				t.Fatalf("got %v, want %v", m.With(tt.Labels).Desc(), tt.ExpectedMetrics)
+			}
+
+			metrics := &pcm.Metric{}
+
+			t.Run("Test increase value", func(t *testing.T) {
+				m.With(tt.Labels).Inc()
+				m.With(tt.Labels).Write(metrics)
+
+				if metrics.Gauge.GetValue() != 1 {
+					t.Fatalf("got %v, want %v", metrics.Gauge.GetValue(), 1)
+				}
+			})
+
+			t.Run("Test decrease value", func(t *testing.T) {
+				m.With(tt.Labels).Dec()
+				m.With(tt.Labels).Write(metrics)
+
+				if metrics.Gauge.GetValue() != 0 {
+					t.Fatalf("got %v, want %v", metrics.Gauge.GetValue(), 0)
+				}
+			})
+		})
+	}
+}
+
+func TestAddCounterVecMultiLabels(t *testing.T) {
+	tests := []struct {
+		Name            string
+		MetricsName     string
+		MetricsHelp     string
+		Labels          prometheus.Labels
+		ExpectedMetrics *prometheus.Desc
+	}{
+		{
+			Name:        "Test metrics is correct",
+			MetricsName: "example_metrics_counter_m",
+			MetricsHelp: "help",
+			Labels:      prometheus.Labels{"host": "127.0.0.1", "port": "6379"},
+			ExpectedMetrics: prometheus.NewDesc(
+				"example_metrics_counter_m",
+				"help",
+				[]string{"host", "port"},
+				prometheus.Labels{},
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			m := AddCounterVecMultiLabels(tt.MetricsName, tt.MetricsHelp)
+
+			if !reflect.DeepEqual(m.With(tt.Labels).Desc(), tt.ExpectedMetrics) {
+				t.Fatalf("got %v, want %v", m.With(tt.Labels).Desc(), tt.ExpectedMetrics)
+			}
+
+			metrics := &pcm.Metric{}
+
+			t.Run("Test increase value", func(t *testing.T) {
+				m.With(tt.Labels).Inc()
+				m.With(tt.Labels).Write(metrics)
+
+				if metrics.Counter.GetValue() != 1 {
+					t.Fatalf("got %v, want %v", metrics.Counter.GetValue(), 1)
+				}
+			})
+		})
+	}
+}

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/nothinux/octo-proxy/pkg/config"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -15,6 +16,8 @@ type Metrics struct {
 
 func New(c config.HostConfig) *Metrics {
 	r := http.NewServeMux()
+	prometheus.Unregister(prometheus.NewGoCollector())
+
 	r.Handle("/metrics", promhttp.Handler())
 
 	srv := &http.Server{

--- a/pkg/proxy/helper.go
+++ b/pkg/proxy/helper.go
@@ -4,13 +4,17 @@ import (
 	"net"
 
 	goerrors "errors"
+
+	"github.com/nothinux/octo-proxy/pkg/config"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
-func errCopy(err error) error {
+func errCopy(err error, tConf config.HostConfig) error {
 	if err != nil {
 		if goerrors.Is(err, net.ErrClosed) {
 			// use of closed network connection
 		} else {
+			upstreamConnErr.With(prometheus.Labels{"host": tConf.Host, "port": tConf.Port}).Inc()
 			return err
 		}
 	}

--- a/pkg/proxy/tlsconn.go
+++ b/pkg/proxy/tlsconn.go
@@ -4,6 +4,8 @@ package proxy
 import (
 	"crypto/tls"
 	"crypto/x509"
+	goerrors "errors"
+	"net"
 	"os"
 	"strings"
 
@@ -93,6 +95,20 @@ func getTLSConfig(c config.TLSConfig) (*ProxyTLS, error) {
 	}
 
 	return ptls, nil
+}
+
+func isTLSConn(nc net.Conn) error {
+	if _, ok := nc.(*tls.Conn); ok {
+		if err := nc.(*tls.Conn).Handshake(); err != nil {
+			return err
+		}
+
+		if !nc.(*tls.Conn).ConnectionState().HandshakeComplete {
+			return goerrors.New("handshake failed")
+		}
+	}
+
+	return nil
 }
 
 func getCACertPool(c config.TLSConfig) (*x509.CertPool, error) {


### PR DESCRIPTION
currently octo-proxy track the connection without separating metrics for upstream and downstream. This PR adds new metrics for `upstream` and `downstream` and removes old metrics.

```
octo_downstream_conn_active
octo_downstream_conn_total
octo_downstream_conn_error
octo_upstream_conn_active
octo_upstream_conn_total
octo_upstream_conn_error
octo_upstream_dial_error
octo_mirror_dial_error
```