### PR TITLE
feat(conn): add new connection config

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ servers:
   listener:
     host: 0.0.0.0
     port: 8080
-    tlsConfig:
+    tls:
       mode: simple
       cert: /tmp/cert.pem
       key: /tmp/cert-key.pem

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ servers:
   listener:
     host: 0.0.0.0
     port: 8080
-    tlsConfig:
+    tls:
       mode: mutual
       caCert: /tmp/ca-cert.pem
       cert: /tmp/cert.pem

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -19,9 +19,14 @@
 | --------- | ------------- | ------------------------------- | -------- |
 | host      | `<string>`    | On `listener`, this is host where listener will be listen, and on `target` and `mirror` this is host of backend where request will be forwarded | yes      |
 | port      | `<string>`    | On `listener`, this is port where listener will be bind, and on `target` and `mirror` this is port of backend where request will be forwarded | yes      |
-| timeout   | `<string>`    | set timeout (in second) or deadline for every connection, default 300 seconds. A value of 0 will disable deadlines on connections | no      |
-| tlsConfig | [`tlsConfig`](#tlsconfig)   | set tls configuration if host use tls | no      |
+| connection   | [`connectionConfig`](#connectionConfig)    | set timeout (in second) or deadline for every connection, default 300 seconds. A value of 0 will disable deadlines on connections | no      |
+| tls       | [`tlsConfig`](#tlsconfig)   | set tls configuration if host use tls | no      |
 
+
+## connectionConfig
+| Field    | Type          | Description                     | Required |
+| -------- | ------------- | ------------------------------- | -------- |
+| timeout  | `<string>`    | Set timeout or deadline for every connection, you can set in milliseconds with `ms` or seconds `s`. default 300 seconds. A value of 0 will disable deadlines on connections                 | no       |
 
 ## tlsConfig
 | Field    | Type          | Description                     | Required |

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -3,20 +3,22 @@ servers:
   listener:
     host: 127.0.0.1
     port: 8080
-    tlsConfig:
+    tls:
       mode: mutual
       cert: certs/localhost.pem
       key: certs/localhost-key.pem
       caCert: certs/ca-cert.pem
-    # set timeout default is 300
-    timeout: 60
+    # set timeout default is 300 seconds
+    connection:
+      timeout: 60s
   targets:
     - host: 172.17.0.2
       port: 80
-      timeout: 60
-      tlsConfig:
+      tls:
         mode: simple
         caCert: certs/ca-cert.pem
+      connection:
+        timeout: 59s
   mirror:
     host: 172.17.0.3
     port: 80

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -127,15 +127,19 @@ func TestGenerateConfig(t *testing.T) {
 					{
 						Name: "default",
 						Listener: HostConfig{
-							Host:            "127.0.0.1",
-							Port:            "8080",
-							TimeoutDuration: 300 * time.Second,
+							Host: "127.0.0.1",
+							Port: "8080",
+							ConnectionConfig: ConnectionConfig{
+								TimeoutDuration: 300 * time.Second,
+							},
 						},
 						Targets: []HostConfig{
 							{
-								Host:            "127.0.0.1",
-								Port:            "80",
-								TimeoutDuration: 300 * time.Second,
+								Host: "127.0.0.1",
+								Port: "80",
+								ConnectionConfig: ConnectionConfig{
+									TimeoutDuration: 300 * time.Second,
+								},
 							},
 						},
 					},
@@ -305,15 +309,19 @@ func TestValidateConfig(t *testing.T) {
 					{
 						Name: "proxy-1",
 						Listener: HostConfig{
-							Host:            "127.0.0.1",
-							Port:            "8080",
-							TimeoutDuration: 300 * time.Second,
+							Host: "127.0.0.1",
+							Port: "8080",
+							ConnectionConfig: ConnectionConfig{
+								TimeoutDuration: 300 * time.Second,
+							},
 						},
 						Targets: []HostConfig{
 							{
-								Host:            "127.0.0.1",
-								Port:            "80",
-								TimeoutDuration: 300 * time.Second,
+								Host: "127.0.0.1",
+								Port: "80",
+								ConnectionConfig: ConnectionConfig{
+									TimeoutDuration: 300 * time.Second,
+								},
 							},
 						},
 					},
@@ -602,9 +610,11 @@ func TestValidateConfig(t *testing.T) {
 					{
 						Name: "proxy-1",
 						Listener: HostConfig{
-							Host:    "127.0.0.1",
-							Port:    "8080",
-							Timeout: "10",
+							Host: "127.0.0.1",
+							Port: "8080",
+							ConnectionConfig: ConnectionConfig{
+								Timeout: "10s",
+							},
 						},
 						Targets: []HostConfig{
 							{
@@ -620,16 +630,20 @@ func TestValidateConfig(t *testing.T) {
 					{
 						Name: "proxy-1",
 						Listener: HostConfig{
-							Host:            "127.0.0.1",
-							Port:            "8080",
-							Timeout:         "10",
-							TimeoutDuration: 10 * time.Second,
+							Host: "127.0.0.1",
+							Port: "8080",
+							ConnectionConfig: ConnectionConfig{
+								Timeout:         "10s",
+								TimeoutDuration: 10 * time.Second,
+							},
 						},
 						Targets: []HostConfig{
 							{
-								Host:            "127.0.0.1",
-								Port:            "80",
-								TimeoutDuration: 300 * time.Second,
+								Host: "127.0.0.1",
+								Port: "80",
+								ConnectionConfig: ConnectionConfig{
+									TimeoutDuration: 300 * time.Second,
+								},
 							},
 						},
 					},
@@ -637,21 +651,22 @@ func TestValidateConfig(t *testing.T) {
 			},
 		},
 		{
-			Name: "set zero timeout",
+			Name: "set timeout on listener using ms",
 			Config: &Config{
 				ServerConfigs: []ServerConfig{
 					{
 						Name: "proxy-1",
 						Listener: HostConfig{
-							Host:    "127.0.0.1",
-							Port:    "8080",
-							Timeout: "0",
+							Host: "127.0.0.1",
+							Port: "8080",
+							ConnectionConfig: ConnectionConfig{
+								Timeout: "10ms",
+							},
 						},
 						Targets: []HostConfig{
 							{
-								Host:    "127.0.0.1",
-								Port:    "80",
-								Timeout: "0",
+								Host: "127.0.0.1",
+								Port: "80",
 							},
 						},
 					},
@@ -662,17 +677,20 @@ func TestValidateConfig(t *testing.T) {
 					{
 						Name: "proxy-1",
 						Listener: HostConfig{
-							Host:            "127.0.0.1",
-							Port:            "8080",
-							Timeout:         "0",
-							TimeoutDuration: 0,
+							Host: "127.0.0.1",
+							Port: "8080",
+							ConnectionConfig: ConnectionConfig{
+								Timeout:         "10ms",
+								TimeoutDuration: 10 * time.Millisecond,
+							},
 						},
 						Targets: []HostConfig{
 							{
-								Host:            "127.0.0.1",
-								Port:            "80",
-								Timeout:         "0",
-								TimeoutDuration: 0,
+								Host: "127.0.0.1",
+								Port: "80",
+								ConnectionConfig: ConnectionConfig{
+									TimeoutDuration: 300 * time.Second,
+								},
 							},
 						},
 					},
@@ -680,21 +698,25 @@ func TestValidateConfig(t *testing.T) {
 			},
 		},
 		{
-			Name: "set zero timeout",
+			Name: "set zero timeout on listener & target",
 			Config: &Config{
 				ServerConfigs: []ServerConfig{
 					{
 						Name: "proxy-1",
 						Listener: HostConfig{
-							Host:    "127.0.0.1",
-							Port:    "8080",
-							Timeout: "0",
+							Host: "127.0.0.1",
+							Port: "8080",
+							ConnectionConfig: ConnectionConfig{
+								Timeout: "0",
+							},
 						},
 						Targets: []HostConfig{
 							{
-								Host:    "127.0.0.1",
-								Port:    "80",
-								Timeout: "0",
+								Host: "127.0.0.1",
+								Port: "80",
+								ConnectionConfig: ConnectionConfig{
+									Timeout: "0",
+								},
 							},
 						},
 					},
@@ -705,17 +727,21 @@ func TestValidateConfig(t *testing.T) {
 					{
 						Name: "proxy-1",
 						Listener: HostConfig{
-							Host:            "127.0.0.1",
-							Port:            "8080",
-							Timeout:         "0",
-							TimeoutDuration: 0,
+							Host: "127.0.0.1",
+							Port: "8080",
+							ConnectionConfig: ConnectionConfig{
+								Timeout:         "0",
+								TimeoutDuration: 0,
+							},
 						},
 						Targets: []HostConfig{
 							{
-								Host:            "127.0.0.1",
-								Port:            "80",
-								Timeout:         "0",
-								TimeoutDuration: 0,
+								Host: "127.0.0.1",
+								Port: "80",
+								ConnectionConfig: ConnectionConfig{
+									Timeout:         "0",
+									TimeoutDuration: 0,
+								},
 							},
 						},
 					},
@@ -729,9 +755,11 @@ func TestValidateConfig(t *testing.T) {
 					{
 						Name: "proxy-1",
 						Listener: HostConfig{
-							Host:    "127.0.0.1",
-							Port:    "8080",
-							Timeout: "foo",
+							Host: "127.0.0.1",
+							Port: "8080",
+							ConnectionConfig: ConnectionConfig{
+								Timeout: "foo",
+							},
 						},
 						Targets: []HostConfig{
 							{
@@ -746,7 +774,7 @@ func TestValidateConfig(t *testing.T) {
 			expectedError:  "failed to parse timeout servers.[0]: strconv.Atoi: parsing \"foo\": invalid syntax",
 		},
 		{
-			Name: "set invalid timeout on listener",
+			Name: "set invalid timeout on target",
 			Config: &Config{
 				ServerConfigs: []ServerConfig{
 					{
@@ -757,9 +785,11 @@ func TestValidateConfig(t *testing.T) {
 						},
 						Targets: []HostConfig{
 							{
-								Host:    "127.0.0.1",
-								Port:    "80",
-								Timeout: "foo",
+								Host: "127.0.0.1",
+								Port: "80",
+								ConnectionConfig: ConnectionConfig{
+									Timeout: "foo",
+								},
 							},
 						},
 					},
@@ -785,15 +815,17 @@ func TestValidateConfig(t *testing.T) {
 							},
 						},
 						Mirror: HostConfig{
-							Host:    "127.0.0.1",
-							Port:    "81",
-							Timeout: "foo",
+							Host: "127.0.0.1",
+							Port: "81",
+							ConnectionConfig: ConnectionConfig{
+								Timeout: "-1",
+							},
 						},
 					},
 				},
 			},
 			expectedConfig: nil,
-			expectedError:  "failed to parse timeout servers.[0].mirror: strconv.Atoi: parsing \"foo\": invalid syntax",
+			expectedError:  "failed to parse timeout servers.[0].mirror: can't use negative value for timeout",
 		},
 		{
 			Name: "set timeout on listener, target and set mirror to default",
@@ -802,15 +834,13 @@ func TestValidateConfig(t *testing.T) {
 					{
 						Name: "proxy-1",
 						Listener: HostConfig{
-							Host:    "127.0.0.1",
-							Port:    "8080",
-							Timeout: "10",
+							Host: "127.0.0.1",
+							Port: "8080",
 						},
 						Targets: []HostConfig{
 							{
-								Host:    "127.0.0.1",
-								Port:    "80",
-								Timeout: "200",
+								Host: "127.0.0.1",
+								Port: "80",
 							},
 						},
 						Mirror: HostConfig{
@@ -825,23 +855,27 @@ func TestValidateConfig(t *testing.T) {
 					{
 						Name: "proxy-1",
 						Listener: HostConfig{
-							Host:            "127.0.0.1",
-							Port:            "8080",
-							Timeout:         "10",
-							TimeoutDuration: 10 * time.Second,
+							Host: "127.0.0.1",
+							Port: "8080",
+							ConnectionConfig: ConnectionConfig{
+								TimeoutDuration: 300 * time.Second,
+							},
 						},
 						Targets: []HostConfig{
 							{
-								Host:            "127.0.0.1",
-								Port:            "80",
-								Timeout:         "200",
-								TimeoutDuration: 200 * time.Second,
+								Host: "127.0.0.1",
+								Port: "80",
+								ConnectionConfig: ConnectionConfig{
+									TimeoutDuration: 300 * time.Second,
+								},
 							},
 						},
 						Mirror: HostConfig{
-							Host:            "127.0.0.1",
-							Port:            "9999",
-							TimeoutDuration: 300 * time.Second,
+							Host: "127.0.0.1",
+							Port: "9999",
+							ConnectionConfig: ConnectionConfig{
+								TimeoutDuration: 300 * time.Second,
+							},
 						},
 					},
 				},
@@ -877,9 +911,11 @@ func TestValidateConfig(t *testing.T) {
 					{
 						Name: "proxy-1",
 						Listener: HostConfig{
-							Host:            "127.0.0.1",
-							Port:            "8080",
-							TimeoutDuration: 300 * time.Second,
+							Host: "127.0.0.1",
+							Port: "8080",
+							ConnectionConfig: ConnectionConfig{
+								TimeoutDuration: 300 * time.Second,
+							},
 							TLSConfig: TLSConfig{
 								Role: Role{
 									Server: true,
@@ -892,9 +928,11 @@ func TestValidateConfig(t *testing.T) {
 						},
 						Targets: []HostConfig{
 							{
-								Host:            "127.0.0.1",
-								Port:            "80",
-								TimeoutDuration: 300 * time.Second,
+								Host: "127.0.0.1",
+								Port: "80",
+								ConnectionConfig: ConnectionConfig{
+									TimeoutDuration: 300 * time.Second,
+								},
 							},
 						},
 					},
@@ -1142,15 +1180,19 @@ func TestValidateConfig(t *testing.T) {
 					{
 						Name: "proxy-1",
 						Listener: HostConfig{
-							Host:            "127.0.0.1",
-							Port:            "8080",
-							TimeoutDuration: 300 * time.Second,
+							Host: "127.0.0.1",
+							Port: "8080",
+							ConnectionConfig: ConnectionConfig{
+								TimeoutDuration: 300 * time.Second,
+							},
 						},
 						Targets: []HostConfig{
 							{
-								Host:            "127.0.0.1",
-								Port:            "80",
-								TimeoutDuration: 300 * time.Second,
+								Host: "127.0.0.1",
+								Port: "80",
+								ConnectionConfig: ConnectionConfig{
+									TimeoutDuration: 300 * time.Second,
+								},
 							},
 						},
 					},
@@ -1173,7 +1215,7 @@ func TestValidateConfig(t *testing.T) {
 			}
 
 			if !reflect.DeepEqual(config, tt.expectedConfig) {
-				t.Fatalf("got %v, want %v", config, tt.expectedConfig)
+				t.Fatalf("\ngot %v, \nwant %v", config, tt.expectedConfig)
 			}
 		})
 	}

--- a/pkg/proxy/dialer.go
+++ b/pkg/proxy/dialer.go
@@ -54,11 +54,8 @@ func dialTargets(hcs []config.HostConfig) (net.Conn, config.HostConfig, error) {
 		*tConf = hc
 		c, err := dialTarget(hc)
 		if err == nil {
-			t := hc.TimeoutDuration
-			if t > 0 {
-				if err := c.SetDeadline(time.Now().Add(t)); err != nil {
-					log.Error().Err(err).Msg("Failed to set deadline")
-				}
+			if !timeoutIsZero(hc) {
+				c.SetDeadline(time.Now().Add(hc.TimeoutDuration))
 			}
 			return c, *tConf, nil
 		}
@@ -93,11 +90,8 @@ func getTargets(c config.ServerConfig) ([]net.Conn, io.Writer, config.HostConfig
 				Msg("can't dial mirror backend")
 		}
 		if m != nil {
-			t := c.Mirror.TimeoutDuration
-			if t > 0 {
-				if err := m.SetDeadline(time.Now().Add(t)); err != nil {
-					log.Error().Err(err).Msg("Failed to set deadline for mirror")
-				}
+			if !timeoutIsZero(c.Mirror) {
+				m.SetDeadline(time.Now().Add(c.Mirror.TimeoutDuration))
 			}
 		}
 	}

--- a/pkg/proxy/helper.go
+++ b/pkg/proxy/helper.go
@@ -21,3 +21,7 @@ func errCopy(err error, tConf config.HostConfig) error {
 
 	return nil
 }
+
+func timeoutIsZero(c config.HostConfig) bool {
+	return c.ConnectionConfig.TimeoutDuration == 0
+}

--- a/pkg/proxy/helper_test.go
+++ b/pkg/proxy/helper_test.go
@@ -1,1 +1,45 @@
 package proxy
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nothinux/octo-proxy/pkg/config"
+)
+
+func TestTimeoutIsZero(t *testing.T) {
+	tests := []struct {
+		Name     string
+		Config   config.HostConfig
+		Response bool
+	}{
+		{
+			Name: "Timeout is zero",
+			Config: config.HostConfig{
+				ConnectionConfig: config.ConnectionConfig{
+					TimeoutDuration: time.Duration(0) * time.Second,
+				},
+			},
+			Response: true,
+		},
+		{
+			Name: "Timeout is not zero",
+			Config: config.HostConfig{
+				ConnectionConfig: config.ConnectionConfig{
+					TimeoutDuration: time.Duration(100) * time.Second,
+				},
+			},
+			Response: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			r := timeoutIsZero(tt.Config)
+
+			if r != tt.Response {
+				t.Fatalf("got %v, want %v", r, tt.Response)
+			}
+		})
+	}
+}

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -109,9 +109,11 @@ func TestProxyWithMirror(t *testing.T) {
 		t.Fatal(err)
 	}
 	cfg.ServerConfigs[0].Mirror = config.HostConfig{
-		Host:            strings.Split(mirror, ":")[0],
-		Port:            strings.Split(mirror, ":")[1],
-		TimeoutDuration: 10 * time.Second,
+		Host: strings.Split(mirror, ":")[0],
+		Port: strings.Split(mirror, ":")[1],
+		ConnectionConfig: config.ConnectionConfig{
+			TimeoutDuration: 10 * time.Second,
+		},
 	}
 
 	p := New("test-proxy")


### PR DESCRIPTION
- Change tls configuration from `tlsConfig` to `tls`.
- Introduce new configuration to control connection `connection`.
- Move `timeout` configuration  from `HostConfig` to `connection`.
- Add ability to define timeout in milliseconds `ms`

```
- name: webserver
  listener:
    host: 127.0.0.1
    port: 8081
    connection:
      timeout: 1s
  targets:
    - host: 127.0.0.1
      port: 80
      connection:
        timeout: 800ms
```